### PR TITLE
Fix typo in Space Details View for cell_hours_reservations.

### DIFF
--- a/SpotSeeker/ViewControllers/SpaceDetailsViewController.m
+++ b/SpotSeeker/ViewControllers/SpaceDetailsViewController.m
@@ -573,7 +573,7 @@
     } else if (hours_notes != nil) {
         if (reservation_notes != nil) {
             // hours & reservation notes exist
-            cell_id = @"notes_bubble_cell_hours_reservation";
+            cell_id = @"notes_bubble_cell_hours_reservations";
         } else {
             // only hours notes
             cell_id = @"notes_bubble_cell_hours";
@@ -912,7 +912,7 @@
     } else if (hours_notes != nil) {
         if (reservation_notes != nil) {
             // hours & reservation notes exist
-            cell_id = @"notes_bubble_cell_hours_reservation";
+            cell_id = @"notes_bubble_cell_hours_reservations";
         } else {
             // only hours notes
             cell_id = @"notes_bubble_cell_hours";


### PR DESCRIPTION
Typo causes the cell with that name to not be loaded.
Space(s) used to test: Suzallo room(s).

Lesson re-learned: Never assume - I assumed I already fulfilled the testing matrix.